### PR TITLE
Add ocf.io SPF record

### DIFF
--- a/etc/zones/db.ocf.io
+++ b/etc/zones/db.ocf.io
@@ -5,4 +5,7 @@ $TTL 1h
 
 $INCLUDE /srv/dns/etc/zones/db.ocf
 
+; Sender Policy Framework (SPF) record
+@ IN TXT "v=spf1 -all"
+
 ; vim: noet ts=16 sts=16 sw=16 ft=bindzone


### PR DESCRIPTION
I left the serial number alone, since we can wait and include this change in the next zone update.