### PR TITLE
remove old dns sig files when deploying new DNS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
         label 'deploy'
       }
       steps {
+        sh 'find /srv/dns \( -name "*.jbk" -o -name "*.signed*" \) -delete'
         puppetTrigger('ns')
       }
     }


### PR DESCRIPTION
I don't recall if this has recently been a problem when deploying DNS, but I do remember long periods of confusion as to why old DNS records were being served because these files would take precedence over the new zones we pushed. This just deletes the old files before the puppet run that pulls the new ones.