### PR TITLE
add rpz and override i.fluffy.cc

### DIFF
--- a/etc/named.conf.local
+++ b/etc/named.conf.local
@@ -46,3 +46,9 @@ zone "0.0.0.0.1.0.8.8.0.4.1.f.7.0.6.2.ip6.arpa" {
   notify yes;
   file "/srv/dns/etc/zones/db.0.0.0.0.1.0.8.8.0.4.1.f.7.0.6.2.ip6.arpa";
 };
+
+zone "rpz" {
+  type master;
+  notify yes;
+  file "/srv/dns/etc/zones/db.rpz";
+};

--- a/etc/zones/db.rpz
+++ b/etc/zones/db.rpz
@@ -1,0 +1,13 @@
+$ORIGIN rpz.
+$TTL 5m
+
+@ IN SOA localhost. none.localhost. (
+2019051200 ; serial number
+                         1d         ; slave refresh schedule interval
+                         30m        ; slave retry on failure interval
+                         4w         ; slave expiration of zone data
+                         30m        ; negative TTL
+                       )
+@ IN NS localhost.
+
+i.fluffy.cc CNAME d31rxpgvqhrnsq.cloudfront.net.


### PR DESCRIPTION
i.fluffy.cc is intercepted by campus networks because it got on some
malware trackers. :( Unfortunately we use fluffy a lot so this allows
us to manually get the correct DNS result.