### PR TITLE
Add CNAME record for all OCF hosted sites

### DIFF
--- a/templates/db.ocf.tmpl
+++ b/templates/db.ocf.tmpl
@@ -34,6 +34,11 @@ dev-dev-vhost                 IN   MX   5   dev-anthrax
 _xmpp-client._tcp 18000 IN SRV 0 5 5222 flood.ocf.berkeley.edu.
 _xmpp-server._tcp 18000 IN SRV 0 5 5269 flood.ocf.berkeley.edu.
 
+; CNAME record for all OCF hosted sites
+hosting IN A    169.229.226.23
+hosting IN AAAA 2607:f140:8801::1:23
+hosting IN MX   5 anthrax
+
 {records}
 
 ; vim: noet ts=16 sts=16 sw=16 ft=bindzone


### PR DESCRIPTION
We'll be asking DNS to use this CNAME record for all websites from now on instead of the A/AAAA to death and MX to anthrax records.

```dns
group.studentorg.berkeley.edu IN CNAME hosting.ocf.berkeley.edu.
```